### PR TITLE
Update ownership info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,12 @@ In this short guide, you will get a quick overview of how you can contribute to 
 
 If you encounter an issue with anki-sm-2 and would like to report it, you'll first want to make sure you're using the latest version of anki-sm-2.
 
-The latest version of anki-sm-2 can be found under [releases](https://github.com/joshdavham/anki-sm-2/releases) and you can verify the version of your current installation with the following command:
+The latest version of anki-sm-2 can be found under [releases](https://github.com/open-spaced-repetition/anki-sm-2/releases) and you can verify the version of your current installation with the following command:
 ```
 pip show anki-sm-2
 ```
 
-Once you've confirmed your version, please report your issue in the [issues tab](https://github.com/joshdavham/anki-sm-2/issues).
+Once you've confirmed your version, please report your issue in the [issues tab](https://github.com/open-spaced-repetition/anki-sm-2/issues).
 
 ## Contributing code
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,26 @@
+<div align="center">
+  <img src="https://avatars.githubusercontent.com/u/96821265?s=200&v=4" height="100" alt="Open Spaced Repetition logo"/>
+</div>
+<div align="center">
+
 # Anki SM-2
+</div>
+
+<div align="center">
+  <em>🌟 Anki's SM-2-based spaced repetition algorithm 🌟</em>
+</div>
+<br />
+<div align="center" style="text-decoration: none;">
+    <a href="https://pypi.org/project/anki-sm-2/"><img src="https://img.shields.io/pypi/v/anki-sm-2"></a>
+    <a href="https://github.com/open-spaced-repetition/anki-sm-2/blob/main/LICENSE" style="text-decoration: none;"><img src="https://img.shields.io/badge/License-AGPL--3.0-brightgreen.svg"></a>
+</div>
+<br />
+
+<div align="left">
+    <strong>
+    Python package implementing Anki's <a href="https://docs.ankiweb.net/deck-options.html#new-cards">SM-2-based algorithm</a> for spaced repetition scheduling.
+    </strong>
+</div>
 
 ## Installation
 
@@ -101,4 +123,8 @@ Once this package is considered stable, the **Major** version will be bumped to 
 
 ## Contribute
 
-Checkout [CONTRIBUTING](https://github.com/joshdavham/anki-sm-2/blob/main/CONTRIBUTING.md) to help improve Anki SM-2!
+Checkout [CONTRIBUTING](https://github.com/open-spaced-repetition/anki-sm-2/blob/main/CONTRIBUTING.md) to help improve Anki SM-2!
+
+## Official implementation
+
+You can find the code for Anki's official Rust-based scheduler [here](https://github.com/ankitects/anki/tree/main/rslib/src/scheduler).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anki-sm-2"
-version = "0.1.0"
+version = "0.1.1"
 description = "Anki SM-2 based spaced repetition scheduler"
 readme = "README.md"
 authors = [{ name = "Joshua Hamilton", email = "hamiltonjoshuadavid@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "Joshua Hamilton", email = "hamiltonjoshuadavid@gmail.com" }
 license = { file = "LICENSE" }
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: GNU Affero General Public License v3",
     "Operating System :: OS Independent"
 ]
 keywords=['anki', 'sm-2', 'spaced-repetition', 'flashcard']


### PR DESCRIPTION
I made some changes to the repo since transferring the ownership from my personal github account to the Open Spaced Repetition group.

At a high level, these changes are:

Update links
Update the license
Add OSR logo
Bump patch number so this package can be re-released on PyPI with updated information